### PR TITLE
Add github action to build images

### DIFF
--- a/.github/workflows/image-quic-reverse-http-tunnel.yaml
+++ b/.github/workflows/image-quic-reverse-http-tunnel.yaml
@@ -1,0 +1,70 @@
+name: quic-reverse-http-tunnel image
+
+on:
+  release:
+    types:
+    - published
+  push:
+    branches:
+    - main
+    tags:
+    - v*
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+
+jobs:
+  buildAndPush:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: ghcr.io/${{ github.repository_owner }}/quic-reverse-http-tunnel/quic-client
+            target: quic-client
+          - image: ghcr.io/${{ github.repository_owner }}/quic-reverse-http-tunnel/quic-client-tcp
+            target: quic-client-tcp
+          - image: ghcr.io/${{ github.repository_owner }}/quic-reverse-http-tunnel/quic-server
+            target: quic-server
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Docker meta
+      uses: docker/metadata-action@v3
+      id: meta
+      with:
+        images: ${{ matrix.image }}
+        tags: |
+          type=semver,pattern={{raw}}
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          type=sha
+        flavor: |
+          latest=${{ github.ref == 'refs/heads/main' }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        target: ${{ matrix.target }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,19 @@ RUN make install
 FROM gcr.io/distroless/static-debian12:nonroot as distroless-static
 
 ############# server
-FROM distroless-static AS server
+FROM distroless-static AS quic-server
 COPY --from=builder /go/bin/server /server
 WORKDIR /
 ENTRYPOINT ["/server"]
 
 ############# client
-FROM distroless-static AS client
+FROM distroless-static AS quic-client
 COPY --from=builder /go/bin/client /client
 WORKDIR /
 ENTRYPOINT ["/client"]
 
 ############# client-tcp
-FROM distroless-static AS client-tcp
+FROM distroless-static AS quic-client-tcp
 COPY --from=builder /go/bin/client-tcp /client-tcp
 WORKDIR /
 ENTRYPOINT ["/client-tcp"]

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY              := ghcr.io/gardener/quic-reverse-http-tunnel
+REGISTRY              ?= ghcr.io/gardener/quic-reverse-http-tunnel
 CLIENT_IMAGE_NAME     := $(REGISTRY)/quic-client
 CLIENT_TCP_IMAGE_NAME := $(REGISTRY)/quic-client-tcp
 SERVER_IMAGE_NAME     := $(REGISTRY)/quic-server
-VERSION               := v0.1.4
+IMAGE_TAG             ?= local-dev
 
 LOCAL_CERTS_DIR := dev/certs
 LOCAL_CERTS     := $(LOCAL_CERTS_DIR)/ca.crt $(LOCAL_CERTS_DIR)/ca.key $(LOCAL_CERTS_DIR)/client.crt $(LOCAL_CERTS_DIR)/client.key $(LOCAL_CERTS_DIR)/tls.crt $(LOCAL_CERTS_DIR)/tls.key
@@ -47,24 +47,15 @@ start-client-tcp: $(LOCAL_CERTS)
 		--upstream=www.example.com:80 \
 		--v=2
 
-#################################################################
-# Rules related to binary build, Docker image build and release #
-#################################################################
+########################################################
+# Rules related to binary build and Docker image build #
+########################################################
 
 .PHONY: docker-images
 docker-images:
-	@docker build --platform linux/amd64,linux/arm64 -t $(CLIENT_IMAGE_NAME):$(VERSION) -t $(CLIENT_IMAGE_NAME):latest -f Dockerfile --target client .
-	@docker build --platform linux/amd64,linux/arm64 -t $(CLIENT_TCP_IMAGE_NAME):$(VERSION) -t $(CLIENT_TCP_IMAGE_NAME):latest -f Dockerfile --target client-tcp .
-	@docker build --platform linux/amd64,linux/arm64 -t $(SERVER_IMAGE_NAME):$(VERSION) -t $(SERVER_IMAGE_NAME):latest -f Dockerfile --target server .
-
-.PHONY: push-docker-images
-push-docker-images:
-	@docker push $(CLIENT_IMAGE_NAME):$(VERSION)
-	@docker push $(CLIENT_TCP_IMAGE_NAME):$(VERSION)
-	@docker push $(SERVER_IMAGE_NAME):$(VERSION)
-	@docker push $(CLIENT_IMAGE_NAME):latest
-	@docker push $(CLIENT_TCP_IMAGE_NAME):latest
-	@docker push $(SERVER_IMAGE_NAME):latest
+	@docker build --platform linux/amd64,linux/arm64 -t $(CLIENT_IMAGE_NAME):$(IMAGE_TAG) -t $(CLIENT_IMAGE_NAME):latest -f Dockerfile --target quic-client .
+	@docker build --platform linux/amd64,linux/arm64 -t $(CLIENT_TCP_IMAGE_NAME):$(IMAGE_TAG) -t $(CLIENT_TCP_IMAGE_NAME):latest -f Dockerfile --target quic-client-tcp .
+	@docker build --platform linux/amd64,linux/arm64 -t $(SERVER_IMAGE_NAME):$(IMAGE_TAG) -t $(SERVER_IMAGE_NAME):latest -f Dockerfile --target quic-server .
 
 .PHONY: install
 install:

--- a/README.md
+++ b/README.md
@@ -59,15 +59,13 @@ Docker images are available at:
 - `ghcr.io/gardener/quic-reverse-http-tunnel/quic-client:latest`
 - `ghcr.io/gardener/quic-reverse-http-tunnel/quic-client-tcp:latest`
 
-If you want to use a specific version tag, the latest version is specified in the `VERSION` variable in the repository's [`Makefile`](./Makefile).
+If you want to use a specific version tag, check the [`tags` of the gardener/quic-reverse-http-tunnel](https://github.com/gardener/quic-reverse-http-tunnel/tags) repository.
 
-When you want to update the docker images and push a new version:
-1. Bump the `VERSION` variable in the repository's [`Makefile`](./Makefile)
-1. Run the following command to build new images:
-    ```console
-    make docker-images
-    ```
-1. Run the following command to push the images to `ghcr.io/gardener/quic-reverse-http-tunnel`
-    ```console
-    make push-docker-images
-    ```
+A [github action](./.github/workflows/image-quic-reverse-http-tunnel.yaml) takes care of building and pushing new images to `ghcr.io` when a new github tag is created.
+
+To build the images locally, you can use the `make docker-images` command:
+```console
+REGISTRY=<your-registry> IMAGE_TAG=<your-image-tag>  make docker-images
+```
+
+**Note** that if you do not specify the `REGISTRY` and `IMAGE_TAG` variables, the default ones from the [`Makefile`](./Makefile) will be used.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a github action which can build docker images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I removed the `make push-docker-images` command and changed the corresponding documentation, because those should not be necessary any more as pushing updated docker images will be handled by the github action.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
