### PR TITLE
Add `kind/enhancement` label to dependabot PRs and PR template

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,8 +8,12 @@ updates:
   open-pull-requests-limit: 5
   allow:
   - dependency-name: "github.com/quic-go/quic-go"
+  labels:
+  - kind/enhancement
 # Create PRs for golang version updates
 - package-ecosystem: docker
   directory: /
   schedule:
     interval: daily
+  labels:
+  - kind/enhancement

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,15 @@
+<!-- Please ensure that you do not include company internal information. -->
+
+**How to categorize this PR?**
+<!--
+Please select the kind of this pull request, e.g.:
+/kind enhancement
+
+Tide will not merge your PR, if it is missing a `kind/*` label.
+"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+/kind TODO
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
Adds comment to use a `kind` label categorization in the PR template.
Also adds `kind/enhancement` labels to PRs opened by dependabot

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
